### PR TITLE
[BC] - Improve Secret performance and syntax 

### DIFF
--- a/config/src/test/scala/com/geirolz/app/toolkit/config/SecretSuite.scala
+++ b/config/src/test/scala/com/geirolz/app/toolkit/config/SecretSuite.scala
@@ -1,12 +1,24 @@
 package com.geirolz.app.toolkit.config
 
-import com.geirolz.app.toolkit.config.Secret.{DeObfuser, Obfuser, ObfuserTuple}
+import com.geirolz.app.toolkit.config.Secret.{DeObfuser, Obfuser, ObfuserTuple, SecretNoLongerValid}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
 import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
 
 class SecretSuite extends munit.ScalaCheckSuite {
+
+  testObfuserTupleFor[String]
+  testObfuserTupleFor[Int]
+  testObfuserTupleFor[Short]
+  testObfuserTupleFor[Char]
+  testObfuserTupleFor[Byte]
+  testObfuserTupleFor[Float]
+  testObfuserTupleFor[Double]
+  testObfuserTupleFor[Boolean]
+  testObfuserTupleFor[BigInt]
+  testObfuserTupleFor[BigDecimal]
 
   test("shuffleAndXorBytes works properly returning the same value for the same seed and value") {
     val seed: Long    = 1111
@@ -29,30 +41,66 @@ class SecretSuite extends munit.ScalaCheckSuite {
     )
   }
 
-  testBiObfuser[String]
-  testBiObfuser[Int]
-  testBiObfuser[Short]
-  testBiObfuser[Char]
-  testBiObfuser[Byte]
-  testBiObfuser[Float]
-  testBiObfuser[Double]
-  testBiObfuser[Boolean]
-  testBiObfuser[BigInt]
-  testBiObfuser[BigDecimal]
+  private def testObfuserTupleFor[T: Arbitrary: ObfuserTuple](implicit c: ClassTag[T]): Unit = {
 
-  private def testBiObfuser[T: Arbitrary: ObfuserTuple](implicit c: ClassTag[T]): Unit = {
-
-    property(s"BiObfuser equals for type ${c.runtimeClass.getSimpleName} always return false") {
+    property(s"Secret equals for type ${c.runtimeClass.getSimpleName} always return false") {
       forAll { (value: T) =>
         assert(Secret(value) != Secret(value))
       }
     }
 
-    property(s"BiObfuser obfuscate and deobfuscate type ${c.runtimeClass.getSimpleName} properly") {
+    // use
+    property(s"Secret obfuscate and de-obfuscate type ${c.runtimeClass.getSimpleName} properly - use") {
       forAll { (value: T) =>
         assertEquals(
-          obtained = Secret(value).use,
+          obtained = Secret(value).use[Try],
+          expected = Success(value)
+        )
+      }
+    }
+
+    property(s"Secret obfuscate and de-obfuscate type ${c.runtimeClass.getSimpleName} properly - useE") {
+      forAll { (value: T) =>
+        assertEquals(
+          obtained = Secret(value).useE,
           expected = Right(value)
+        )
+      }
+    }
+
+    // useAndDestroy
+    property(s"Secret obfuscate and de-obfuscate type ${c.runtimeClass.getSimpleName} properly - useAndDestroy") {
+      forAll { (value: T) =>
+        val secret: Secret[T] = Secret(value)
+        assertEquals(
+          obtained = secret.useAndDestroy[Try],
+          expected = Success(value)
+        )
+        assertEquals(
+          obtained = secret.useAndDestroy[Try],
+          expected = Failure(SecretNoLongerValid())
+        )
+        assertEquals(
+          obtained = secret.isDestroyed,
+          expected = true
+        )
+      }
+    }
+
+    property(s"Secret obfuscate and de-obfuscate type ${c.runtimeClass.getSimpleName} properly - useAndDestroyE") {
+      forAll { (value: T) =>
+        val secret: Secret[T] = Secret(value)
+        assertEquals(
+          obtained = secret.useAndDestroyE,
+          expected = Right(value)
+        )
+        assertEquals(
+          obtained = secret.useAndDestroyE,
+          expected = Left(SecretNoLongerValid())
+        )
+        assertEquals(
+          obtained = secret.isDestroyed,
+          expected = true
         )
       }
     }


### PR DESCRIPTION
* Avoid calling gc every time to destroy the secret. Nulling the internal value it's enough to securely destroy the information. This were causing performance issue.
* [Breaking-changes] Now `use` method is monadic and take an `F` using a `MonadThrow` instance, the either version has been renamed `useE` and `useAndDestroyE`.
* [Breaking-changes] `NoLongerValidSecret` has been renamed into `SecretNoLongerValid`

```scala
val secret: Secret[Int] = Secret(10)
secret.useAndDestroy[IO] // IO[Int]

val secret: Secret[Int] = Secret(10)
secret.useAndDestroyE[IO] // Either[SecretNoLongerValid, Int] 
```